### PR TITLE
We're moving to a Python 3.8+ minimum requirement

### DIFF
--- a/.github/workflows/clean-ecr.yml
+++ b/.github/workflows/clean-ecr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   clean-ecr:
     name: Clean ECR
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In production, this app is used to redirect legacy domains/paths.
 Requirements
 ------------
 
-- Python 3.6+
+- Python 3.8+
 
 Unlike most Prisoner Money apps, this one does not use the REST api.
 


### PR DESCRIPTION
We're in the process to update `base`/`base-web` Docker images to use
a newer version of Ubuntu (`20.04`) which comes with Python 3.8 and
we're updating all repositories to suggest using 3.8 minumum.

Although this application does **NOT** uses `base-web` as a base image
(in fact it's already using Python 3.9) it makes sense to update this
README for consistency.

Related to ticket: https://dsdmoj.atlassian.net/browse/MTP-1841