### PR TITLE
IR-1693 Fix ECR cleanup failing on untagged images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
 
             if [[ "${CIRCLE_BRANCH}" != "main" ]]; then
               echo "Deleting other images from branch ${CIRCLE_BRANCH}"
-              IMAGES_TO_DELETE=$(aws ecr describe-images --repository-name ${ECR_REPOSITORY} --query 'imageDetails[?contains(map(&starts_with(@, '"'"${app}.${CIRCLE_BRANCH_LOWERCASE}."'"'), @.imageTags), `true`) && ! contains(@.imageTags, '"'"${tag}"'"')].imageDigest' --output text)
+              IMAGES_TO_DELETE=$(aws ecr describe-images --repository-name ${ECR_REPOSITORY} --query 'imageDetails[?@.imageTags && contains(map(&starts_with(@, '"'"${app}.${CIRCLE_BRANCH_LOWERCASE}."'"'), @.imageTags), `true`) && ! contains(@.imageTags, '"'"${tag}"'"')].imageDigest' --output text)
               delete_images
             fi
 


### PR DESCRIPTION
## Problem

The CircleCI `Clean up ECR` step fails on non-`main` branches with:

```
aws: [ERROR]: In function map(), invalid type for value: None, expected one of: ['array'], received: "null"
Exited with code exit status 255
```

The `aws ecr describe-images` query runs `map(&starts_with(...), @.imageTags)`, but `@.imageTags` is `null` for untagged images (e.g. multi-arch manifest-list sub-images that the earlier 'delete untagged images' phase can't remove because they're referenced by a manifest list). `map()` over `null` makes the AWS CLI exit 255 and fails the build. Build/test/push/deploy all succeed — only this post-deploy housekeeping step fails.

## Fix

Guard the JMESPath filter with `@.imageTags &&` so images without tags short-circuit out before `map()` is evaluated. Verified locally with the `jmespath` library: the old query raises the exact error, the new one returns the correct branch images to prune.

Same one-line fix is being applied across all affected money-to-prisoners repos under IR-1693.