### PR TITLE
IR-1740 Add GitHub Actions build-test-push workflow

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -1,0 +1,112 @@
+# NOTE: bespoke workflow for start-page — not generated from the shared
+# templates-apps generator (the generator skips build-test-push.yml for it).
+# Unlike the Django apps, start-page runs its tests on the host (flake8 +
+# pytest) and builds a self-contained image (python:3.14-alpine, no base-web).
+name: Build, test and push
+on:
+  push:
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  build-test-push:
+    name: Build, test and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # --- test on the host (Flask app; not containerised for tests) ---
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      - name: Install python dependencies
+        run: pip install -r requirements.txt -r requirements-tests.txt
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: |
+          mkdir -p reports
+          pytest --capture no --junit-xml reports/pytest.xml
+      - name: Publish test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: reports
+          if-no-files-found: warn
+
+      # --- build + push image ---
+      - name: Assume IAM role to access ECR
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ vars.ECR_REGION }}
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+      - name: Log docker into ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Compute image tags
+        id: tags
+        run: |
+          branch_lc=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
+          version=${branch_lc}.${GITHUB_SHA::7}
+          tag=start-page.${version}
+          registry=${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "registry=${registry}" >> "$GITHUB_OUTPUT"
+          echo "Building ${tag}"
+      - name: Build docker image
+        env:
+          TAG: ${{ steps.tags.outputs.tag }}
+        run: |
+          docker build \
+            --pull --force-rm \
+            --build-arg APP_GIT_COMMIT=${GITHUB_SHA} \
+            --build-arg APP_GIT_BRANCH=${GITHUB_REF_NAME} \
+            --build-arg APP_BUILD_TAG=${TAG} \
+            --build-arg APP_BUILD_DATE=$(date +%FT%T%z) \
+            --tag ${TAG} \
+            .
+      - name: Push docker image
+        env:
+          TAG: ${{ steps.tags.outputs.tag }}
+          REGISTRY: ${{ steps.tags.outputs.registry }}
+        run: |
+          echo "Pushing ${TAG} to ECR"
+          docker tag ${TAG} ${REGISTRY}:${TAG}
+          docker push ${REGISTRY}:${TAG}
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            echo "Pushing start-page to ECR (acts as latest)"
+            docker tag ${TAG} ${REGISTRY}:start-page
+            docker push ${REGISTRY}:start-page
+          fi
+
+      # --- deploy to test on main (gated; dormant during dual-run) ---
+      - name: Install kubectl
+        if: ${{ github.ref_name == 'main' && vars.GHA_DEPLOY_ENABLED == 'true' }}
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.32.9
+      - name: Deploy to test
+        if: ${{ github.ref_name == 'main' && vars.GHA_DEPLOY_ENABLED == 'true' }}
+        env:
+          TAG: ${{ steps.tags.outputs.tag }}
+          VERSION: ${{ steps.tags.outputs.version }}
+          REGISTRY: ${{ steps.tags.outputs.registry }}
+          K8S_CLUSTER_CERT: ${{ secrets.K8S_CLUSTER_CERT }}
+          K8S_CLUSTER_NAME: ${{ secrets.K8S_CLUSTER_NAME }}
+          K8S_CLUSTER_SERVER: ${{ secrets.K8S_CLUSTER_SERVER }}
+          K8S_NAMESPACE: ${{ secrets.K8S_NAMESPACE }}
+          K8S_TOKEN: ${{ secrets.K8S_TOKEN }}
+        run: |
+          echo "Deploying to test"
+          echo -n "${K8S_CLUSTER_CERT}" | base64 -d > /tmp/mtp-k8s-ca.crt
+          kubectl config set-cluster ${K8S_CLUSTER_NAME} --certificate-authority=/tmp/mtp-k8s-ca.crt --server=${K8S_CLUSTER_SERVER}
+          kubectl config set-credentials github-actions --token=${K8S_TOKEN}
+          kubectl config set-context ${K8S_CLUSTER_NAME} --cluster=${K8S_CLUSTER_NAME} --user=github-actions --namespace=${K8S_NAMESPACE}
+          kubectl config use-context ${K8S_CLUSTER_NAME}
+          IMAGE=${REGISTRY}:${TAG}
+          kubectl patch configmap app-versions --patch "{\"data\": {\"start-page\": \"${VERSION}\"}}"
+          kubectl patch deployment start-page --type strategic --patch "{\"metadata\": {\"annotations\": {\"kubernetes.io/change-cause\": \"${VERSION}\"}}, \"spec\": {\"template\": {\"spec\": {\"containers\": [{\"name\": \"app\", \"image\": \"${IMAGE}\"}], \"initContainers\": [{\"name\": \"copy-static\", \"image\": \"${IMAGE}\"}]}}}}"


### PR DESCRIPTION
## What

Adds a **bespoke** `.github/workflows/build-test-push.yml` for start-page. Part of the CircleCI → GitHub Actions migration (IR-1740).

Unlike the Django apps, start-page (a Flask site) runs its tests **on the host** and builds a **self-contained** image, so it doesn't fit the shared template (deploy#510 makes the generator skip it).

## Behaviour

On every push, in parallel with CircleCI (dual-run):
- **host tests**: `flake8` + `pytest --junit-xml` on Python 3.14,
- **build** the `python:3.14-alpine` image (`--pull`, no base-web), **push** `start-page.<branch>.<sha7>` (and `:start-page` latest on main).

The **deploy** step patches the web Deployment (`copy-static` init container) and is gated behind `GHA_DEPLOY_ENABLED` (unset) — CircleCI remains sole deployer during dual-run. No new secrets needed for build/test/push.