### PR TITLE
IR-1782 Dual-push start-page images to GHCR

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  packages: write
 jobs:
   build-test-push:
     name: Build, test and push
@@ -46,6 +47,12 @@ jobs:
       - name: Log docker into ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+      - name: Log docker into GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Compute image tags
         id: tags
         run: |
@@ -53,9 +60,11 @@ jobs:
           version=${branch_lc}.${GITHUB_SHA::7}
           tag=start-page.${version}
           registry=${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}
+          ghcr_package=ghcr.io/${{ github.repository_owner }}/money-to-prisoners-start-page
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "registry=${registry}" >> "$GITHUB_OUTPUT"
+          echo "ghcr_package=${ghcr_package}" >> "$GITHUB_OUTPUT"
           echo "Building ${tag}"
       - name: Build docker image
         env:
@@ -72,15 +81,23 @@ jobs:
       - name: Push docker image
         env:
           TAG: ${{ steps.tags.outputs.tag }}
+          VERSION: ${{ steps.tags.outputs.version }}
           REGISTRY: ${{ steps.tags.outputs.registry }}
+          GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
         run: |
           echo "Pushing ${TAG} to ECR"
           docker tag ${TAG} ${REGISTRY}:${TAG}
           docker push ${REGISTRY}:${TAG}
+          echo "Pushing ${VERSION} to GHCR ${GHCR_PACKAGE}"
+          docker tag ${TAG} ${GHCR_PACKAGE}:${VERSION}
+          docker push ${GHCR_PACKAGE}:${VERSION}
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
             echo "Pushing start-page to ECR (acts as latest)"
             docker tag ${TAG} ${REGISTRY}:start-page
             docker push ${REGISTRY}:start-page
+            echo "Pushing latest to GHCR"
+            docker tag ${TAG} ${GHCR_PACKAGE}:latest
+            docker push ${GHCR_PACKAGE}:latest
           fi
 
       # --- deploy to test on main (gated; dormant during dual-run) ---


### PR DESCRIPTION
Completes Phase 2 of IR-1782. All eight app repos now publish to GHCR.

This repo was **wrongly left out of the first Phase 2 round** — I had recorded it
as still building on CircleCI, which is out of date: it has had a GitHub Actions
`build-test-push.yml` and no `.circleci` directory for some time. Correcting that.

**Hand-edited, not generated.** This workflow is bespoke — tests run on the host
(flake8 + pytest) and the image is self-contained from `python:3.14-alpine`
rather than built on `base-web`.

## What changes

- `packages: write` and a `docker/login-action` step for ghcr.io.
- Pushes to ECR **exactly as before**, and additionally to
  `ghcr.io/ministryofjustice/money-to-prisoners-start-page`, tagged
  `[branch].[sha]` plus `latest` on `main`.
- **No base image pull to move** — unlike the Django apps, this image does not
  build on `base-web`, so there is nothing to repoint at the GHCR base package.
- **Deploys are unchanged** — `Deploy to test` still resolves to ECR.

## No .dockerignore change here

The other repos gained a `**/settings/local.py` exclusion, to stop a local
`docker build` baking a developer's settings into a now-public image. That does
not apply here: this is a Flask app whose only settings module (`app/settings.py`)
is tracked, and `.gitignore` contains nothing but caches and `venv/`. There is no
local override pattern to exclude.

## Verified before raising

- workflow YAML parses
- 2 ECR pushes and 2 GHCR pushes, one GHCR login, `packages: write` present
- `Deploy to test` still builds its image reference from `${REGISTRY}` (ECR)

## After merge

The package inherits this repo's visibility, so it will be created **public** and
linked automatically, with no manual step.
