### PR TITLE
IR-1782 Stop pushing images to ECR

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -6,7 +6,6 @@ name: Build, test and push
 on:
   push:
 permissions:
-  id-token: write
   contents: read
   packages: write
 jobs:
@@ -39,14 +38,6 @@ jobs:
           if-no-files-found: warn
 
       # --- build + push image ---
-      - name: Assume IAM role to access ECR
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-region: ${{ vars.ECR_REGION }}
-          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      - name: Log docker into ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
       - name: Log docker into GHCR
         uses: docker/login-action@v3
         with:
@@ -59,11 +50,9 @@ jobs:
           branch_lc=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
           version=${branch_lc}.${GITHUB_SHA::7}
           tag=start-page.${version}
-          registry=${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}
           ghcr_package=ghcr.io/${{ github.repository_owner }}/money-to-prisoners-start-page
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "registry=${registry}" >> "$GITHUB_OUTPUT"
           echo "ghcr_package=${ghcr_package}" >> "$GITHUB_OUTPUT"
           echo "Building ${tag}"
       - name: Build docker image
@@ -82,19 +71,12 @@ jobs:
         env:
           TAG: ${{ steps.tags.outputs.tag }}
           VERSION: ${{ steps.tags.outputs.version }}
-          REGISTRY: ${{ steps.tags.outputs.registry }}
           GHCR_PACKAGE: ${{ steps.tags.outputs.ghcr_package }}
         run: |
-          echo "Pushing ${TAG} to ECR"
-          docker tag ${TAG} ${REGISTRY}:${TAG}
-          docker push ${REGISTRY}:${TAG}
           echo "Pushing ${VERSION} to GHCR ${GHCR_PACKAGE}"
           docker tag ${TAG} ${GHCR_PACKAGE}:${VERSION}
           docker push ${GHCR_PACKAGE}:${VERSION}
           if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
-            echo "Pushing start-page to ECR (acts as latest)"
-            docker tag ${TAG} ${REGISTRY}:start-page
-            docker push ${REGISTRY}:start-page
             echo "Pushing latest to GHCR"
             docker tag ${TAG} ${GHCR_PACKAGE}:latest
             docker push ${GHCR_PACKAGE}:latest


### PR DESCRIPTION
Final phase of IR-1782 — this repo stops pushing to ECR. Depends on [deploy#546](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/546).

Prod has run from GHCR since the cutover, so the parallel ECR push is no longer a fallback worth keeping. This workflow is bespoke (matrix-sharded tests), so it is hand-edited rather than generated.

## Simpler than the other repos, because the shards were pulling from ECR

`build` pushed the branch-sha tag to ECR specifically so the `check` job and the 16 `test` shards could pull it back down, and each of those jobs assumed the IAM role to do so.

The GHCR package is **public**, so they now pull it with no credentials at all. That removes the assume-role and ECR login from five jobs, not just one:

- `build`, `check`, `test` (×16), `push`, `deploy`

`id-token: write` goes with them — it existed only for OIDC into AWS.

## What stays the same

The image the shards test is still the exact artefact built by `build` and later promoted to `latest` — pulled by digest-identical tag, just from the other registry. `push` now retags the GHCR version rather than pulling from ECR to retag.

Verified the YAML parses and all five jobs keep their steps.
