### PR TITLE
IR-1782 Stop a failed vim/sudo install breaking docker-compose

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -9,9 +9,15 @@ USER root
 
 # Having a text editor in a dev container is super useful
 # Also sudo is needed to install anything further as mtp user
+#
+# Deliberately best-effort: Docker Desktop's DNS frequently cannot resolve
+# dl-cdn.alpinelinux.org (other hosts on the same container resolve fine), and these are a
+# convenience rather than something the app needs. Failing hard here took down the whole of
+# `docker-compose up`, because compose builds every service before starting any of them.
 RUN apk add \
   vim \
-  sudo
+  sudo \
+  || echo 'WARNING: could not install vim/sudo; continuing without them'
 
 COPY --chown=mtp:mtp . /app/
 


### PR DESCRIPTION
`docker-compose up` still fails after #785, on this step:

```
RUN apk add vim sudo

WARNING: updating and opening https://dl-cdn.alpinelinux.org/alpine/v3.24/main/aarch64/APKINDEX.tar.gz: DNS: transient error
ERROR: unable to select packages:
  sudo (no such package)
  vim (no such package)
```

## Cause

Docker Desktop's DNS cannot resolve `dl-cdn.alpinelinux.org`. It is specific to that host — from the same container:

| host | resolves |
|---|---|
| `dl-cdn.alpinelinux.org` | **no** |
| `registry.npmjs.org` | yes |
| `deb.debian.org` | yes |
| `github.com` | yes |

start-page is the only Alpine-based app, which is why it is the only one affected — the rest use apt against `deb.debian.org`.

The reason this breaks *everything* rather than just start-page is that compose builds every service before starting any of them. So one dev container failing to install a text editor takes down the whole local stack.

## Fix

`vim` and `sudo` are a convenience, not a dependency. Install them best-effort and carry on without them if the mirror is unreachable. Not worth pinning a mirror or pinning DNS for two optional tools.

## Verified

Full stack on Apple Silicon, all eight services:

```
api 200   cashbook 200   bank-admin 200   noms-ops 200
send-money 200   start-page 200   emails 200
```

plus Cashbook sign-in as `test-prison-1` → 302 and the authenticated page renders.

This is the first time start-page has been included in that verification — I could not build it previously and wrongly attributed the failure to my own environment. It reproduces on a normal developer machine.